### PR TITLE
Remove padding from native ad bottom app bar layout

### DIFF
--- a/app/src/main/res/layout/ad_bottom_app_bar.xml
+++ b/app/src/main/res/layout/ad_bottom_app_bar.xml
@@ -16,15 +16,13 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            android:background="?attr/colorSurfaceContainer"
-            android:padding="12dp">
+            android:background="?attr/colorSurfaceContainer">
 
             <include layout="@layout/ad_attribution" />
 
             <androidx.appcompat.widget.LinearLayoutCompat
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
                 android:gravity="center_vertical"
                 android:orientation="horizontal">
 
@@ -32,7 +30,6 @@
                     android:id="@+id/ad_app_icon"
                     android:layout_width="48dp"
                     android:layout_height="48dp"
-                    android:layout_marginEnd="12dp"
                     android:visibility="gone" />
 
                 <androidx.appcompat.widget.LinearLayoutCompat
@@ -63,7 +60,6 @@
                     style="@style/Widget.Material3.Button.TextButton"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="8dp"
                     android:minWidth="88dp"
                     android:minHeight="40dp" />
             </androidx.appcompat.widget.LinearLayoutCompat>


### PR DESCRIPTION
## Summary
- remove padding and margins from the bottom app bar native ad layout to match the updated design

## Testing
- `bash gradlew test` *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e394f95404832d8413d888836cd20e